### PR TITLE
Appl 73  - added Package object, updated docs, tests.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Changes
 * *0.1.1* - Added VersionUtilsError and RpmError classes. RpmError is thrown
   if a package string cannot be parsed. All errors inherit from
   VersionUtilsError
-* *0.2.0* - Added :any:`Package` class and :any:`rpm.package` method to return
-  a Package object when parsing package strings. Deprecated public access to
-  the :any:`rpm.parse_package` method, although the function remains unchanged
-  for backwards compatibility.
+* *0.2.0* - Added :any:`common.Package` class and :any:`rpm.package` method to
+  return a Package object when parsing package strings. Deprecated public
+  access to the :any:`rpm.parse_package` method, although the function remains
+  unchanged for backwards compatibility.

--- a/README.rst
+++ b/README.rst
@@ -43,20 +43,54 @@ present. The example below uses the ``rpm`` module. From your application::
     
     # Get a package string for an installed package
     out, err = Popen(['rpm', '-q', 'foo'], stdout=PIPE, stderr=PIPE).communicate()
-    sys_pkg = out
+    sys_pkg_str = out
     
     # Get package information
-    sys_pkg_info = rpm.parse_package(sys_pkg)
-    sys_pkg_ver = sys_pkg_info['EVR'][1]
-    
+    sys_package = rpm.package(sys_package)
+    sys_pkg_name = sys_package.name
+    sys_pkg_version = sys_package.version
+
     # Compare versions
-    result = rpm.compare_versions(pkg_req, sys_pkg_ver)
+    result = rpm.compare_versions(pkg_req, sys_pkg_version)
     
     if result < 0:  # sys_pkg was newer
-        print('System package does not satisfy requirement!')
+        print('System package {0} does not satisfy
+              requirement!'.format(sys_pkg_name))
 
-Note that ``parse_package`` returns a 3-tuple ``(epoc, version, requirement)``,
-so if you only need to compare on version, you can pull it out from the tuple.
+In addition to indirectly comparing versions, a :any:`compare_packages`
+function is provided to directly compare package strings, using the
+same logic as the package manager::
+
+    from version_utils import rpm
+
+    sys_pkg = 'perl-Compress-Raw-Zlib-2.021-136.el6_6.1.x86_64'
+    repo_pkg = 'perl-Compress-Raw-Zlib-2.021-138.el6_6.1.x86_64'
+
+    result = rpm.compare_packages(repo_pkg, sys_pkg)
+
+    if result > 0:  # repo_pkg is newer
+        print('Repo package is newer')
+
+The :any:`Package` class can be used to succinctly transmit package
+information::
+
+    from version_utils import rpm
+
+    pkg_str = 'pkgconfig-0.23-9.1.el6.x86_64'
+    pkg = rpm.package(pkg_str)
+
+    # Get package name, epoch, version, release, and architecture as a tuple
+    print(pkg.info)
+
+    # Access the package string that was parsed to make the Package object
+    print(pkg.package)
+
+    # Access the epoch, version, and release information as a tuple
+    print(pkg.evr)
+
+    # Access name, epoch, version, release, and architecture independently
+    print('Name: {0}, Epoch: {1}, Version: {2}, Release: {3}, Arch:
+          {4}'.format(pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch))
 
 Changes
 -------
@@ -65,3 +99,7 @@ Changes
 * *0.1.1* - Added VersionUtilsError and RpmError classes. RpmError is thrown
   if a package string cannot be parsed. All errors inherit from
   VersionUtilsError
+* *0.2.0* - Added :any:`Package` class and :any:`rpm.package` method to return
+  a Package object when parsing package strings. Deprecated public access to
+  the :any:`rpm.parse_package` method, although the function remains unchanged
+  for backwards compatibility.

--- a/docs/version_utils.common.rst
+++ b/docs/version_utils.common.rst
@@ -1,0 +1,7 @@
+version_utils.common module
+===========================
+
+.. automodule:: version_utils.common
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/version_utils.errors.rst
+++ b/docs/version_utils.errors.rst
@@ -1,0 +1,7 @@
+version_utils.errors module
+===========================
+
+.. automodule:: version_utils.errors
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/version_utils.rst
+++ b/docs/version_utils.rst
@@ -6,6 +6,8 @@ Submodules
 
 .. toctree::
 
+   version_utils.common
+   version_utils.errors
    version_utils.rpm
 
 Module contents

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = ('version_utils is a pure Python convenience library for'
 
 setup(
     name='version_utils',
-    version='0.1.1',
+    version='0.2.0',
     description=('Library for parsing system package strings and comparing '
                  'package versions'),
     url='http://www.github.com/ihiji/version_utils',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,10 +13,12 @@ except ImportError:
     from mock import MagicMock, patch
 
 from logging import getLogger
+from sys import path
 
 logger = getLogger(__name__)
 
 
+path.append('..')
 from version_utils import common
 from version_utils.common import Package
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,12 +13,10 @@ except ImportError:
     from mock import MagicMock, patch
 
 from logging import getLogger
-from sys import path
 
 logger = getLogger(__name__)
 
 
-path.append('..')
 from version_utils import common
 from version_utils.common import Package
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,36 @@
+"""
+Test module for version_utils
+"""
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+try:
+    from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
+
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+
+from version_utils import common
+from version_utils.common import Package
+
+
+class CommonTestCase(unittest.TestCase):
+    """Standard tests for the common module"""
+
+    def test_string_repr(self):
+        pkg = common.Package(name='test', epoch='0', version='1.0',
+                             release='1', arch='i386', package='test_str.str')
+        new_pkg = eval(repr(pkg))
+        self.assertEqual("Package Object: ('test', '0', '1.0', '1', 'i386')",
+                         str(new_pkg))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,12 +13,13 @@ except ImportError:
     from mock import MagicMock, patch
 
 from logging import getLogger
+from sys import path
 
 logger = getLogger(__name__)
 
 
+path.append('..')
 from version_utils import common
-from version_utils.common import Package
 
 
 class CommonTestCase(unittest.TestCase):

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -4,18 +4,23 @@ Test module for version_utils
 
 try:
     import unittest2 as unittest
-    from mock import MagicMock, patch
 except ImportError:
     import unittest
+
+try:
     from unittest.mock import MagicMock, patch
+except ImportError:
+    from mock import MagicMock, patch
 
 from logging import getLogger
 
 from version_utils import rpm
+from version_utils import errors
 
 
 logger = getLogger(__name__)
 
+# Version strings for testing, along with their parsed information
 version_strings = {
             'nmap-6.40-1.i386': {
                 'name': 'nmap',
@@ -104,6 +109,7 @@ version_strings = {
         }
 
 class RpmTestCase(unittest.TestCase):
+    """Tests for standard RPM module usage"""
 
     def test_pop_arch(self):
         for vs, info in version_strings.items():
@@ -112,12 +118,29 @@ class RpmTestCase(unittest.TestCase):
             self.assertEqual(info['arch'], arch)
 
     def test_parse_information(self):
+        """test the parse_information function for all version_strings"""
         for vs, info in version_strings.items():
             evr = (info['epoch'], info['version'], info['release'])
             parsed = rpm.parse_package(vs)
             self.assertEqual(info['name'], parsed['name'])
             self.assertEqual(evr, parsed['EVR'])
             self.assertEqual(info['arch'], parsed['arch'])
+
+    def test_package(self):
+        """Test the package function with all verison_strings"""
+        for vs, info in version_strings.items():
+            expect = (info['name'], info['epoch'], info['version'],
+                      info['release'], info['arch'])
+            pkg = rpm.package(vs)
+            self.assertEqual(expect, pkg.info)
+
+    def test_parse_package_bad_package_no_arch(self):
+        with self.assertRaises(errors.RpmError):
+            rpm.parse_package('what_even_is_this_thing')
+
+    def test_parse_package_bad_package(self):
+        with self.assertRaises(errors.RpmError):
+            rpm.parse_package('blargleblargle.aiiii')
 
     def test_check_leading(self):
         test_strs = [

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -13,7 +13,9 @@ except ImportError:
     from mock import MagicMock, patch
 
 from logging import getLogger
+from sys import path
 
+path.append('..')
 from version_utils import rpm
 from version_utils import errors
 

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -13,9 +13,7 @@ except ImportError:
     from mock import MagicMock, patch
 
 from logging import getLogger
-from sys import path
 
-path.append('..')
 from version_utils import rpm
 from version_utils import errors
 

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -13,7 +13,9 @@ except ImportError:
     from mock import MagicMock, patch
 
 from logging import getLogger
+from sys import path
 
+path.append('..')
 from version_utils import rpm
 from version_utils import errors
 
@@ -127,7 +129,7 @@ class RpmTestCase(unittest.TestCase):
             self.assertEqual(info['arch'], parsed['arch'])
 
     def test_package(self):
-        """Test the package function with all verison_strings"""
+        """Test the package function with all version_strings"""
         for vs, info in version_strings.items():
             expect = (info['name'], info['epoch'], info['version'],
                       info['release'], info['arch'])

--- a/version_utils/common.py
+++ b/version_utils/common.py
@@ -1,0 +1,57 @@
+"""
+Module for implementation of functionality common to various package
+management systems.
+"""
+
+# Standard library imports
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+from logging import getLogger
+
+# Local imports
+
+logger = getLogger(__name__)
+
+
+class Package(object):
+    """A class to hold information about a system package
+
+    All parameters except ``name`` are optional and default to None
+
+    :param str name: package name
+    :param str epoch: epoch string, default None
+    :param str version: version string, default None
+    :param str release: release string, default None
+    :param str arch: architecture string, default None
+    :param str package: original package manager style package string,
+        default None
+    :ivar str name: package name
+    :ivar str epoch: package epoch
+    :ivar str version: package version
+    :ivar str arch: package architecture
+    :ivar tuple evr: a 3-tuple containing (epoch, version, release)
+    :ivar tuple info: a 5-tuple containing (name, epoch, version, release,
+        architecture)
+    :ivar str package: the system-style package string
+    """
+
+    def __init__(self, name, epoch=None, version=None, release=None,
+                 arch=None, package=None):
+        self.name = name
+        self.epoch = epoch
+        self.version = version
+        self.release = release
+        self.arch = arch
+        self.evr = (epoch, version, release)
+        self.info = (name, epoch, version, release, arch)
+        self.package = package
+
+    def __str__(self):
+        """Create a string representation of a Package object"""
+        return ('Package Object: {0}'.format(self.info))
+
+    def __repr__(self):
+        """Full representation of a Package object"""
+        return ('Package("{0}", "{1}", "{2}", "{3}", "{4}", '
+                '"{5}")'.format(self.name, self.epoch, self.version,
+                                self.release, self.arch, self.package))

--- a/version_utils/rpm.py
+++ b/version_utils/rpm.py
@@ -8,8 +8,9 @@ Public methods include:
       ``gcc-4.4.7-16.el6.x86_64`` and ``gcc-4.4.7-17.el6.x86_64``
     * :any:`compare_versions`: compare two RPM version strings (the
       bit between the dashes in an RPM package string)
-    * :any:`parse_package`: get name, EVR (epoch, version, release),
-      and architecture information from an RPM package string
+    * :any:`package`: parse an RPM package string to get name, epoch,
+      version, release, and architecture information. Returns as a
+      :any:`common.Package` object.
 """
 
 # Standard library imports
@@ -146,7 +147,7 @@ def compare_versions(version_a, version_b):
 
 
 def package(package_string, arch_included=True):
-    """Parse an RPM version string and return a :any:`Package` object
+    """Parse an RPM version string
 
     Parses most (all tested) RPM version strings to get their name,
     epoch, version, release, and architecture information. Epoch (also
@@ -157,8 +158,9 @@ def package(package_string, arch_included=True):
 
     :param str package_string:
     :param bool arch_included:
-    :return: A `Package` object containing all parsed information
-    :rtype: Package
+    :return: A :any:`common.Package` object containing all parsed
+        information
+    :rtype: common.Package
     """
     logger.debug('package({0}, {1})'.format(package_string, arch_included))
     pkg_info = parse_package(package_string, arch_included)


### PR DESCRIPTION
- New `Package` object now available in `common.py`
- New `rpm.package` function which returns a `Package`
  object instead of the dict returned by `parse_package`
- Documentation reflects deprecation of `parse_package`
- Updated documentation examples
- Updated documentation changelog
- Added tests for new functionality
