### PR TITLE
Fix for Issue #7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python: 3.5
 env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py34
-  - TOX_ENV=py35
+- TOX_ENV=py26
+- TOX_ENV=py27
+- TOX_ENV=py34
+- TOX_ENV=py35
 install:
-  - pip install tox
+- pip install tox
 script:
-  - tox -e $TOX_ENV
+- tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python: 3.4
+env:
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+  - TOX_ENV=py34
+  - TOX_ENV=py35
+install:
+  - pip install tox
+script:
+  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.4
+python: 3.5
 env:
   - TOX_ENV=py26
   - TOX_ENV=py27

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ present. The example below uses the ``rpm`` module. From your application::
               requirement!'.format(sys_pkg_name))
 
 
-In addition to indirectly comparing versions, a `compare_packages`
+In addition to indirectly comparing versions, a ``compare_packages``
 function is provided to directly compare package strings, using the
 same logic as the package manager::
 
@@ -93,8 +93,9 @@ same logic as the package manager::
         print('Repo package is newer')
 
 
-The `Package` class can be used to succinctly transmit package
-information::
+The ``Package`` class can be used to succinctly transmit package
+information. A factory function, ``rpm.package()``, is provided to
+instantiate ``Package`` instances::
 
     from version_utils import rpm
 
@@ -122,8 +123,30 @@ Contributions to ``version_utils`` are welcome. Feel free to fork, raise
 issues, etc.
 
 
+Contributors
+------------
+
+I would like to express my sincere thanks to the following GitHub users for
+their contributions to and assistance with this project:
+
+* Joseph Knight (jknightihiji_)
+* Thomas Hoger (thoger_)
+
+.. _jknightihiji: https://github.com/jknightihiji
+.. _thoger: https://github.com/thoger
+
+
 Changelog
 ---------
+
+0.2.3
++++++
+
+Fixed issue `#7`_ where version strings without epoch strings and with multi-
+digit primary version numbers would return the first digit of the primary
+version as the epoch and the second digit as the primary version.
+
+.. _#7: https://github.com/ihiji/version_utils/issues/7
 
 0.2.2
 +++++

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ present. The example below uses the ``rpm`` module. From your application::
               requirement!'.format(sys_pkg_name))
 
 
-In addition to indirectly comparing versions, a :any:`compare_packages`
+In addition to indirectly comparing versions, a `compare_packages`
 function is provided to directly compare package strings, using the
 same logic as the package manager::
 
@@ -73,7 +73,7 @@ same logic as the package manager::
         print('Repo package is newer')
 
 
-The :any:`Package` class can be used to succinctly transmit package
+The `Package` class can be used to succinctly transmit package
 information::
 
     from version_utils import rpm
@@ -115,10 +115,10 @@ Bugfix release only
 0.2.0
 +++++
 
-Added :any:`common.Package` class and :any:`rpm.package` method to
+Added `common.Package` class and `rpm.package` method to
 return a Package object when parsing package strings.
 
-Deprecated public access to the :any:`rpm.parse_package` method, although the
+Deprecated public access to the `rpm.parse_package` method, although the
 function remains unchanged for backwards compatibility.
 
 0.1.1

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,11 @@ Currently, only RPM/Yum style packages are supported, but we have plans to add
 dpkg/Debian in the near future. Development will probably slow from there, 
 although Pacman/Arch and various other distributions are on the radar.
 
+Note that the ``compare_versions`` function in the ``rpm`` module will probably
+work for the majority of ``.deb`` package versions. However, there are some
+differences, and it will fail in certain cases. Use at your own risk until
+official support for debian version parsing is released.
+
 Installation
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,18 @@
+.. -*- mode: rst; coding: utf-8 -*-
+
+==========================================================
+version_utils - pure python version parsing and comparison
+==========================================================
+
+:Source:        https://github.com/ihiji/version_utils
+:PyPI:          https://pypi.python.org/pypi/version_utils
+:Travis:        https://travis-ci.org/ihiji/version_utils
+:Maintainer:    Matthew Planchard <mplanchard@ihiji.com>
+:License:       GPLv3
+
+.. contents:: Table of Contents
+    :backlinks: top
+
 Introduction
 ------------
 
@@ -107,8 +122,8 @@ Contributions to ``version_utils`` are welcome. Feel free to fork, raise
 issues, etc.
 
 
-Change Log
-----------
+Changelog
+---------
 
 0.2.2
 +++++

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,13 @@ information::
           {4}'.format(pkg.name, pkg.epoch, pkg.version, pkg.release, pkg.arch))
 
 
+Contributing
+------------
+
+Contributions to ``version_utils`` are welcome. Feel free to fork, raise
+issues, etc.
+
+
 Change Log
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,11 @@ Change Log
 
 Added ``version.py`` with automatic version parsing by ``setup.py``
 
+Added ``rpm`` and ``common`` modules to ``__init__.py``
+
+Imported ``__version__`` and ``__version_info__`` information into
+``__init__.py``
+
 Added ``tox.ini`` and tox integration
 
 Improved error handling in the ``compare_versions`` function in ``rpm``

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -107,8 +107,16 @@ version_strings = {
                 'version': '1.~0.1e',
                 'release': '42.el6',
                 'arch': 'x86_64'
+            },
+            'firefox-45.0-4.fc22.x86_64': {
+                'name': 'firefox',
+                'epoch': '0',
+                'version': '45.0',
+                'release': '4.fc22',
+                'arch': 'x86_64'
             }
         }
+
 
 class RpmTestCase(unittest.TestCase):
     """Tests for standard RPM module usage"""

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,10 @@ envlist = py26, py27, py34, py35
 [testenv]
 deps =
     pytest
+    pytest-cov
     py26: mock
     py26: unittest2
     py27: mock
-commands = py.test
+commands = py.test --cov=version_utils
 setenv =
     LOG_LEVEL = DEBUG

--- a/version_utils/rpm.py
+++ b/version_utils/rpm.py
@@ -24,7 +24,7 @@ from version_utils.common import Package
 from version_utils.errors import RpmError
 
 
-_rpm_re = compile('(\S+)-(\d*):?([\w~]+[\w.~]*)-(~?\w+[\w.]*)')
+_rpm_re = compile('(\S+)-(?:(\d*):)?([\w~]+[\w.~]*)-(~?\w+[\w.]*)')
 
 logger = getLogger(__name__)
 
@@ -210,7 +210,8 @@ def parse_package(package_string, arch_included=True):
     except AttributeError:
         raise RpmError('Could not parse package string: '
                        '{0}'.format(package_string))
-    epoch = default_epoch if epoch == '' else epoch
+    if epoch == '' or epoch is None:
+        epoch = default_epoch
     info = {
         'name': name,
         'EVR': (epoch, version, release),

--- a/version_utils/version.py
+++ b/version_utils/version.py
@@ -8,5 +8,5 @@ and also set as the __version__ attribute for the package.
 # Standard library imports
 from __future__ import unicode_literals
 
-__version_info__ = (0, 2, 2)
+__version_info__ = (0, 2, 3)
 __version__ = '.'.join([str(ver) for ver in __version_info__])


### PR DESCRIPTION
Fixes issue #7, in which version strings with no epoch and with multi-digit primary versions were incorrectly parsed. Also adds a test case to ensure that particular issue never crops up again.

This update also improves the documentation, includes coverage information in the test report, and updates integration with Travis. 
