### PR TITLE
Release 0.3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,13 +131,27 @@ their contributions to and assistance with this project:
 
 * Joseph Knight (jknightihiji_)
 * Thomas Hoger (thoger_)
+* Marcus Furlong (furlongm_)
 
 .. _jknightihiji: https://github.com/jknightihiji
 .. _thoger: https://github.com/thoger
+.. _furlongm: https://gibhub.com/furlongm
 
 
 Changelog
 ---------
+
+0.3.0
++++++
+
+Added labelCompare functionality for parity with the official `rpm`
+package
+
+Updated tests to use py.test; added more tests
+
+Improved test logging
+
+Improved logging efficiency with `%s` formatting
 
 0.2.3
 +++++

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,11 +4,18 @@ __init__.py module for version_utils
 
 # Standard library imports
 from __future__ import absolute_import, division, print_function
-from logging import getLogger
+from os import environ
+from sys import path
+import logging
 
 # Third party imports
 
 # Local imports
 
 
-logger = getLogger(__name__)
+logger = logging.getLogger('version_utils')
+
+path.append('..')
+
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler())

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -145,7 +145,21 @@ version_info = [
             'release': '4.fc22',
             'arch': 'x86_64'
         }
+    ),
+    (
+        'aaa_base-13.2+git20140911.61c1681-10.1.x86_64',
+        {
+            'name': 'aaa_base',
+            'epoch': '0',
+            'version': '13.2+git20140911.61c1681',
+            'release': '10.1',
+            'arch': 'x86_64'
+        }
     )
+]
+
+version_info_no_arch = [
+    ('.'.join(i[0].split('.')[:-1]), i[1]) for i in version_info
 ]
 
 
@@ -176,6 +190,16 @@ def test_package(version_info):
     expect = (info['name'], info['epoch'], info['version'],
               info['release'], info['arch'])
     pkg = rpm.package(vs)
+    assert expect == pkg.info
+
+
+@pytest.mark.parametrize('version_info', version_info_no_arch)
+def test_package_no_arch(version_info):
+    """Test the package function with the no_arch option"""
+    vs, info = version_info
+    expect = (info['name'], info['epoch'], info['version'],
+              info['release'], None)
+    pkg = rpm.package(vs, arch_included=False)
     assert expect == pkg.info
 
 

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -2,283 +2,345 @@
 Test module for version_utils
 """
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
-try:
-    from unittest.mock import MagicMock, patch
-except ImportError:
-    from mock import MagicMock, patch
-
+# Builtin imports
 from logging import getLogger
-from sys import path
 
-path.append('..')
+# Third party imports
+import pytest
+
+# Local imports
 from version_utils import rpm
 from version_utils import errors
-
 
 logger = getLogger(__name__)
 
 # Version strings for testing, along with their parsed information
-version_strings = {
-            'nmap-6.40-1.i386': {
-                'name': 'nmap',
-                'epoch': '0',
-                'version': '6.40',
-                'release': '1',
-                'arch': 'i386'
-            },
-            'python-pyinvision-0.2.9-1.noarch': {
-                'name': 'python-pyinvision',
-                'epoch': '0',
-                'version': '0.2.9',
-                'release': '1',
-                'arch': 'noarch'
-            },
-            'gcc-4.4.7-16.el6.x86_64': {
-                'name': 'gcc',
-                'epoch': '0',
-                'version': '4.4.7',
-                'release': '16.el6',
-                'arch': 'x86_64'
-            },
-            'ncurses-libs-5.7-3.20090208.el6.i686': {
-                'name': 'ncurses-libs',
-                'epoch': '0',
-                'version': '5.7',
-                'release': '3.20090208.el6',
-                'arch': 'i686'
-            },
-            'perl-Compress-Raw-Zlib-2.021-136.el6_6.1.x86_64': {
-                'name': 'perl-Compress-Raw-Zlib',
-                'epoch': '0',
-                'version': '2.021',
-                'release': '136.el6_6.1',
-                'arch': 'x86_64'
-            },
-            'libX11-1.6.0-2.2.el6.x86_64': {
-                'name': 'libX11',
-                'epoch': '0',
-                'version': '1.6.0',
-                'release': '2.2.el6',
-                'arch': 'x86_64'
-            },
-            'pkgconfig-0.23-9.1.el6.x86_64': {
-                'name': 'pkgconfig',
-                'epoch': '0',
-                'version': '0.23',
-                'release': '9.1.el6',
-                'arch': 'x86_64'
-            },
-            'ruby-1.8.7.374-4.el6_6.x86_64': {
-                'name': 'ruby',
-                'epoch': '0',
-                'version': '1.8.7.374',
-                'release': '4.el6_6',
-                'arch': 'x86_64'
-            },
-            'openssl-1.0.1e-42.el6.x86_64': {
-                'name': 'openssl',
-                'epoch': '0',
-                'version': '1.0.1e',
-                'release': '42.el6',
-                'arch': 'x86_64'
-            },
-            'ntp-4.2.2p1-9.el5.centos.2.1.x86_64': {
-                'name': 'ntp',
-                'epoch': '0',
-                'version': '4.2.2p1',
-                'release': '9.el5.centos.2.1',
-                'arch': 'x86_64'
-            },
-            'ruby-1:1.8.7.374-4.el6_6.x86_64': {
-                'name': 'ruby',
-                'epoch': '1',
-                'version': '1.8.7.374',
-                'release': '4.el6_6',
-                'arch': 'x86_64'
-            },
-            'openssl-1.~0.1e-42.el6.x86_64': {
-                'name': 'openssl',
-                'epoch': '0',
-                'version': '1.~0.1e',
-                'release': '42.el6',
-                'arch': 'x86_64'
-            },
-            'firefox-45.0-4.fc22.x86_64': {
-                'name': 'firefox',
-                'epoch': '0',
-                'version': '45.0',
-                'release': '4.fc22',
-                'arch': 'x86_64'
-            }
+version_info = [
+    (
+        'nmap-6.40-1.i386',
+        {
+            'name': 'nmap',
+            'epoch': '0',
+            'version': '6.40',
+            'release': '1',
+            'arch': 'i386'
         }
+    ),
+    (
+        'python-pyinvision-0.2.9-1.noarch',
+        {
+            'name': 'python-pyinvision',
+            'epoch': '0',
+            'version': '0.2.9',
+            'release': '1',
+            'arch': 'noarch'
+        }
+    ),
+    (
+        'gcc-4.4.7-16.el6.x86_64',
+        {
+            'name': 'gcc',
+            'epoch': '0',
+            'version': '4.4.7',
+            'release': '16.el6',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'ncurses-libs-5.7-3.20090208.el6.i686',
+        {
+            'name': 'ncurses-libs',
+            'epoch': '0',
+            'version': '5.7',
+            'release': '3.20090208.el6',
+            'arch': 'i686'
+        }
+    ),
+    (
+        'perl-Compress-Raw-Zlib-2.021-136.el6_6.1.x86_64',
+        {
+            'name': 'perl-Compress-Raw-Zlib',
+            'epoch': '0',
+            'version': '2.021',
+            'release': '136.el6_6.1',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'libX11-1.6.0-2.2.el6.x86_64',
+        {
+            'name': 'libX11',
+            'epoch': '0',
+            'version': '1.6.0',
+            'release': '2.2.el6',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'pkgconfig-0.23-9.1.el6.x86_64',
+        {
+            'name': 'pkgconfig',
+            'epoch': '0',
+            'version': '0.23',
+            'release': '9.1.el6',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'ruby-1.8.7.374-4.el6_6.x86_64',
+        {
+            'name': 'ruby',
+            'epoch': '0',
+            'version': '1.8.7.374',
+            'release': '4.el6_6',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'openssl-1.0.1e-42.el6.x86_64',
+        {
+            'name': 'openssl',
+            'epoch': '0',
+            'version': '1.0.1e',
+            'release': '42.el6',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'ntp-4.2.2p1-9.el5.centos.2.1.x86_64',
+        {
+            'name': 'ntp',
+            'epoch': '0',
+            'version': '4.2.2p1',
+            'release': '9.el5.centos.2.1',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'ruby-1:1.8.7.374-4.el6_6.x86_64',
+        {
+            'name': 'ruby',
+            'epoch': '1',
+            'version': '1.8.7.374',
+            'release': '4.el6_6',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'openssl-1.~0.1e-42.el6.x86_64',
+        {
+            'name': 'openssl',
+            'epoch': '0',
+            'version': '1.~0.1e',
+            'release': '42.el6',
+            'arch': 'x86_64'
+        }
+    ),
+    (
+        'firefox-45.0-4.fc22.x86_64',
+        {
+            'name': 'firefox',
+            'epoch': '0',
+            'version': '45.0',
+            'release': '4.fc22',
+            'arch': 'x86_64'
+        }
+    )
+]
 
 
-class RpmTestCase(unittest.TestCase):
-    """Tests for standard RPM module usage"""
-
-    def test_pop_arch(self):
-        for vs, info in version_strings.items():
-            char_list = list(vs)
-            arch = rpm._pop_arch(char_list)
-            self.assertEqual(info['arch'], arch)
-
-    def test_parse_information(self):
-        """test the parse_information function for all version_strings"""
-        for vs, info in version_strings.items():
-            evr = (info['epoch'], info['version'], info['release'])
-            parsed = rpm.parse_package(vs)
-            self.assertEqual(info['name'], parsed['name'])
-            self.assertEqual(evr, parsed['EVR'])
-            self.assertEqual(info['arch'], parsed['arch'])
-
-    def test_package(self):
-        """Test the package function with all version_strings"""
-        for vs, info in version_strings.items():
-            expect = (info['name'], info['epoch'], info['version'],
-                      info['release'], info['arch'])
-            pkg = rpm.package(vs)
-            self.assertEqual(expect, pkg.info)
-
-    def test_parse_package_bad_package_no_arch(self):
-        with self.assertRaises(errors.RpmError):
-            rpm.parse_package('what_even_is_this_thing')
-
-    def test_parse_package_bad_package(self):
-        with self.assertRaises(errors.RpmError):
-            rpm.parse_package('blargleblargle.aiiii')
-
-    def test_check_leading(self):
-        test_strs = [
-            ('1.05', '1.05'),
-            ('.104', '104'),
-            ('~104', '~104'),
-            ('~.4', '~.4'),
-            ('!444', '444')
-        ]
-        for test, expect in test_strs:
-            test_list = list(test)
-            rpm._check_leading(test_list)
-            res = ''.join(test_list)
-            self.assertEqual(expect, res)
-
-    def test_trim_zeros(self):
-        test_strs = [
-            ('0012', '12'),
-            ('120', '120'),
-            ('000000000005', '5'),
-            ('101', '101'),
-            ('0000', '')
-        ]
-        for test, expect in test_strs:
-            test_list = list(test)
-            rpm._trim_zeros(test_list)
-            res = ''.join(test_list)
-            self.assertEqual(expect, res)
-
-    def test_trim_zeros_multi(self):
-        test_strs = [
-            (('0012', '12'), ('120', '120')),
-            (('04', '4'), ('0', ''))
-        ]
-        for test_a, test_b in test_strs:
-            a_test, a_expect = test_a
-            b_test, b_expect = test_b
-            a_list, b_list = list(a_test), list(b_test)
-            rpm._trim_zeros(a_list, b_list)
-            res_a, res_b = ''.join(a_list), ''.join(b_list)
-            self.assertEqual(a_expect, res_a)
-            self.assertEqual(b_expect, res_b)
-
-    def test_pop_digits(self):
-        test_strs = [
-            ('1.05', '1'),
-            ('12.44', '12'),
-            ('12a4.2', '12'),
-            ('aa4', ''),
-            ('.1234', '')
-        ]
-        for test, expect in test_strs:
-            test_list = list(test)
-            digits = rpm._pop_digits(test_list)
-            res = ''.join(digits)
-            self.assertEqual(expect, res)
-
-    def test_pop_letters(self):
-        test_strs = [
-            ('1.00', ''),
-            ('aaer2r', 'aaer'),
-            ('a23', 'a'),
-            ('a.2', 'a'),
-            ('.a22', '')
-        ]
-        for test, expect in test_strs:
-            test_list = list(test)
-            letters = rpm._pop_letters(test_list)
-            res = ''.join(letters)
-            self.assertEqual(expect, res)
-
-    def test_compare_blocks(self):
-        test_blocks = [
-            ('12345', '12345', 0),
-            ('12345', '1234', 1),
-            ('1234', '12345', -1),
-            ('12345', '12346', -1),
-            ('12346', '12345', 1),
-            ('0012', '0012', 0),
-            ('00123', '0012', 1),
-            ('0012', '00123', -1),
-            ('00123', '00124', -1),
-            ('00124', '00123', 1)
-        ]
-        for a, b, exp in test_blocks:
-            list_a, list_b = list(a), list(b)
-            res = rpm._compare_blocks(list_a, list_b)
-            self.assertEqual(exp, res, msg='Got {0} when comparing {1} to '
-                                           '{2}'.format(res, a, b))
-
-    def test_get_block_res(self):
-        test_strs = [
-            ('12.12', '12.13', 0),
-            ('12.12', 'a.13', 1),
-            ('a12.5', '12.5', -1),
-            ('01ab', '01ac', 0),
-            ('012ab', '02ab', 1),
-            ('abc123', 'abc123', 0),
-            ('abd123', 'abc123', 1)
-        ]
-        for a, b, exp in test_strs:
-            list_a, list_b = list(a), list(b)
-            res = rpm._get_block_result(list_a, list_b)
-            self.assertEqual(exp, res, msg='Got {0} when comparing {1} to '
-                                           '{2}'.format(res, a, b))
-
-    def test_compare_versions(self):
-        test_versions = [
-            ('~', 'aoi', -1),
-            ('aoi', '~', 1),
-            ('~', '~', 0),
-            ('~', '~a', -1),
-            ('1a', 'a1', 1),
-            ('1a', '1b', -1),
-            ('a1', 'a2', -1),
-            ('1.2.3', '1.2.4', -1),
-            ('1.02.4', '1.02a.4', 1),
-            ('1.02a.4', '1.02b.4', -1),
-            ('12345.6', '12345.6', 0),
-            ('0.2.3', '1.2.4', -1),
-            ('~1.2.3', '1.2.3', -1),
-            ('1.2.3.a', '1.2.3.~alpha', 1)
-        ]
-        for a, b, exp in test_versions:
-            res = rpm.compare_versions(a, b)
-            self.assertEqual(exp, res, msg='Got {0} when comparing {1} to '
-                                           '{2}'.format(res, a, b))
+@pytest.mark.parametrize('version_info', version_info)
+def test_pop_arch(version_info):
+    """Test the pop_arch function"""
+    vs, info = version_info
+    char_list = list(vs)
+    arch = rpm._pop_arch(char_list)
+    assert info['arch'] == arch
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize('version_info', version_info)
+def test_parse_information(version_info):
+    """test the parse_information function for all version_info"""
+    vs, info = version_info
+    evr = (info['epoch'], info['version'], info['release'])
+    parsed = rpm.parse_package(vs)
+    assert info['name'] == parsed['name']
+    assert evr == parsed['EVR']
+    assert info['arch'] == parsed['arch']
+
+
+@pytest.mark.parametrize('version_info', version_info)
+def test_package(version_info):
+    """Test the package function with all version_info"""
+    vs, info = version_info
+    expect = (info['name'], info['epoch'], info['version'],
+              info['release'], info['arch'])
+    pkg = rpm.package(vs)
+    assert expect == pkg.info
+
+
+evr_list = [
+    (('0', '1.0', '5a'), ('0', '1.0', '5a'), 0),
+    (('0', '1.0', '5a'), ('1', '1.0', '5a'), -1),
+    (('0', '1.1', '5a'), ('0', '1.0', '5a'), 1),
+    (('0', '1.0', '5a'), ('0', '1.0', '5b'), -1),
+]
+
+
+@pytest.mark.parametrize('evr_a,evr_b,exp', evr_list)
+def test_evrs(evr_a, evr_b, exp, func=rpm.compare_evrs):
+    """Test the compare_evrs function"""
+    res = func(evr_a, evr_b)
+    assert res == exp
+
+
+@pytest.mark.parametrize('evr_a,evr_b,exp', evr_list)
+def test_label_compare(evr_a, evr_b, exp):
+    """Test the label_compare function"""
+    test_evrs(evr_a, evr_b, exp, func=rpm.labelCompare)
+
+
+def test_parse_package_bad_package_no_arch():
+    """Test that a package with no architecture raises an error"""
+    with pytest.raises(errors.RpmError):
+        rpm.parse_package('what_even_is_this_thing')
+
+
+def test_parse_package_bad_package():
+    """Test that an unparseable package raises an error"""
+    with pytest.raises(errors.RpmError):
+        rpm.parse_package('blargleblargle.aiiii')
+
+
+@pytest.mark.parametrize('test,expect', [
+    ('1.05', '1.05'),
+    ('.104', '104'),
+    ('~104', '~104'),
+    ('~.4', '~.4'),
+    ('!444', '444')
+])
+def test_check_leading(test, expect):
+    """Check that stripping leading characters works as expected"""
+    test_list = list(test)
+    rpm._check_leading(test_list)
+    res = ''.join(test_list)
+    assert expect == res
+
+
+@pytest.mark.parametrize('test,expect', [
+    ('0012', '12'),
+    ('120', '120'),
+    ('000000000005', '5'),
+    ('101', '101'),
+    ('0000', '')
+])
+def test_trim_zeros(test, expect):
+    """Test that zeros are trimmed as expected"""
+    test_list = list(test)
+    rpm._trim_zeros(test_list)
+    res = ''.join(test_list)
+    assert expect == res
+
+
+@pytest.mark.parametrize('test_a,test_b', [
+    (('0012', '12'), ('120', '120')),
+    (('04', '4'), ('0', ''))
+])
+def test_trim_zeros_multi(test_a, test_b):
+    """Test passing multiple arguments to trim_zeros"""
+    a_test, a_expect = test_a
+    b_test, b_expect = test_b
+    a_list, b_list = list(a_test), list(b_test)
+    rpm._trim_zeros(a_list, b_list)
+    res_a, res_b = ''.join(a_list), ''.join(b_list)
+    assert a_expect == res_a
+    assert b_expect == res_b
+
+
+@pytest.mark.parametrize('test,expect', [
+    ('1.05', '1'),
+    ('12.44', '12'),
+    ('12a4.2', '12'),
+    ('aa4', ''),
+    ('.1234', '')
+])
+def test_pop_digits(test, expect):
+    """Test that digit blocks are properly popped from strings"""
+    test_list = list(test)
+    digits = rpm._pop_digits(test_list)
+    res = ''.join(digits)
+    assert expect == res
+
+
+@pytest.mark.parametrize('test,expect', [
+    ('1.00', ''),
+    ('aaer2r', 'aaer'),
+    ('a23', 'a'),
+    ('a.2', 'a'),
+    ('.a22', '')
+])
+def test_pop_letters(test, expect):
+    """Test that letter blocks are properly popped from strings"""
+    test_list = list(test)
+    letters = rpm._pop_letters(test_list)
+    res = ''.join(letters)
+    assert expect == res
+
+
+@pytest.mark.parametrize('block_a,block_b,exp', [
+    ('12345', '12345', 0),
+    ('12345', '1234', 1),
+    ('1234', '12345', -1),
+    ('12345', '12346', -1),
+    ('12346', '12345', 1),
+    ('0012', '0012', 0),
+    ('00123', '0012', 1),
+    ('0012', '00123', -1),
+    ('00123', '00124', -1),
+    ('00124', '00123', 1),
+    ('aawef', 'bawef', -1),
+    ('boiwjef', 'aawoeijf', 1),
+    ('aaaa', 'aaaa', 0)
+])
+def test_compare_blocks(block_a, block_b, exp):
+    """Test block comparison"""
+    list_a, list_b = list(block_a), list(block_b)
+    res = rpm._compare_blocks(list_a, list_b)
+    assert exp == res
+
+
+@pytest.mark.parametrize('str_a,str_b,exp', [
+    ('12.12', '12.13', 0),
+    ('12.12', 'a.13', 1),
+    ('a12.5', '12.5', -1),
+    ('01ab', '01ac', 0),
+    ('012ab', '02ab', 1),
+    ('abc123', 'abc123', 0),
+    ('abd123', 'abc123', 1)
+])
+def test_get_block_res(str_a, str_b, exp):
+    """Test _get_block_res, which returns the result of the first block"""
+    list_a, list_b = list(str_a), list(str_b)
+    res = rpm._get_block_result(list_a, list_b)
+    assert exp == res
+
+
+@pytest.mark.parametrize('ver_a,ver_b,exp', [
+    ('~', 'aoi', -1),
+    ('aoi', '~', 1),
+    ('~', '~', 0),
+    ('~', '~a', -1),
+    ('1a', 'a1', 1),
+    ('1a', '1b', -1),
+    ('a1', 'a2', -1),
+    ('1.2.3', '1.2.4', -1),
+    ('1.02.4', '1.02a.4', 1),
+    ('1.02a.4', '1.02b.4', -1),
+    ('12345.6', '12345.6', 0),
+    ('0.2.3', '1.2.4', -1),
+    ('~1.2.3', '1.2.3', -1),
+    ('1.2.3.a', '1.2.3.~alpha', 1)
+])
+def test_compare_versions(ver_a, ver_b, exp):
+    res = rpm.compare_versions(ver_a, ver_b)
+    assert exp == res

--- a/version_utils/rpm.py
+++ b/version_utils/rpm.py
@@ -48,14 +48,6 @@ def compare_packages(rpm_str_a, rpm_str_b, arch_provided=True):
     architecture, the ``arch_provided`` parameter should be set to
     False.
 
-    This method compares the epoch, version, and release of the
-    provided package strings, assuming that epoch is 0 if not provided.
-    Comparison is performed on the epoch, then the version, and then
-    the release. If at any point a non-equality is found, the result is
-    returned without any remaining comparisons being performed (e.g. if
-    the epochs of the packages differ, the versions are releases are
-    not compared).
-
     Note that the packages do not have to be the same package (i.e.
     they do not require the same name or architecture).
 
@@ -68,8 +60,27 @@ def compare_packages(rpm_str_a, rpm_str_b, arch_provided=True):
     :rtype: int
     """
     logger.debug('resolve_versions({0}, {1})'.format(rpm_str_a, rpm_str_b))
-    a_epoch, a_ver, a_rel = parse_package(rpm_str_a, arch_provided)['EVR']
-    b_epoch, b_ver, b_rel = parse_package(rpm_str_b, arch_provided)['EVR']
+    evr_a = parse_package(rpm_str_a, arch_provided)['EVR']
+    evr_b = parse_package(rpm_str_b, arch_provided)['EVR']
+    return labelCompare(evr_a, evr_b)
+
+
+def compare_evrs(evr_a, evr_b):
+    """Compare two EVR tuples to determine which is newer
+
+    This method compares the epoch, version, and release of the
+    provided package strings, assuming that epoch is 0 if not provided.
+    Comparison is performed on the epoch, then the version, and then
+    the release. If at any point a non-equality is found, the result is
+    returned without any remaining comparisons being performed (e.g. if
+    the epochs of the packages differ, the versions are releases are
+    not compared).
+
+    :param tuple evr_a: an EVR tuple
+    :param tuple evr_b: an EVR tuple
+    """
+    (a_epoch, a_ver, a_rel) = evr_a
+    (b_epoch, b_ver, b_rel) = evr_b
     if a_epoch != b_epoch:
         return a_newer if a_epoch > b_epoch else b_newer
     ver_comp = compare_versions(a_ver, b_ver)
@@ -77,6 +88,25 @@ def compare_packages(rpm_str_a, rpm_str_b, arch_provided=True):
         return ver_comp
     rel_comp = compare_versions(a_rel, b_rel)
     return rel_comp
+
+
+def labelCompare(evr_a, evr_b):
+    """ Convenience function to provide the same behaviour as
+    labelCompare from rpm-python.
+
+    To be used as a drop-in replacement for labelCompare.
+
+    To use the version_utils version and fall back to rpm:
+
+    try:
+        from version_utils.rpm import labelCompare
+    except ImportError:
+        from rpm import labelCompare
+
+    :param tuple evr_a: an EVR tuple
+    :param tuple evr_b: an EVR tuple
+    """
+    compare_evrs(evr_a, evr_b)
 
 
 def compare_versions(version_a, version_b):

--- a/version_utils/rpm.py
+++ b/version_utils/rpm.py
@@ -59,7 +59,7 @@ def compare_packages(rpm_str_a, rpm_str_b, arch_provided=True):
         (``b`` is newer)
     :rtype: int
     """
-    logger.debug('resolve_versions({0}, {1})'.format(rpm_str_a, rpm_str_b))
+    logger.debug('resolve_versions(%s, %s)', rpm_str_a, rpm_str_b)
     evr_a = parse_package(rpm_str_a, arch_provided)['EVR']
     evr_b = parse_package(rpm_str_b, arch_provided)['EVR']
     return labelCompare(evr_a, evr_b)
@@ -79,8 +79,8 @@ def compare_evrs(evr_a, evr_b):
     :param tuple evr_a: an EVR tuple
     :param tuple evr_b: an EVR tuple
     """
-    (a_epoch, a_ver, a_rel) = evr_a
-    (b_epoch, b_ver, b_rel) = evr_b
+    a_epoch, a_ver, a_rel = evr_a
+    b_epoch, b_ver, b_rel = evr_b
     if a_epoch != b_epoch:
         return a_newer if a_epoch > b_epoch else b_newer
     ver_comp = compare_versions(a_ver, b_ver)
@@ -90,11 +90,14 @@ def compare_evrs(evr_a, evr_b):
     return rel_comp
 
 
+# pylint: disable=invalid-name
+# noinspection PyPep8Naming
 def labelCompare(evr_a, evr_b):
     """ Convenience function to provide the same behaviour as
     labelCompare from rpm-python.
 
-    To be used as a drop-in replacement for labelCompare.
+    To be used as a drop-in replacement for labelCompare, thus the
+    utilization of the non-standard camelCase variable name.
 
     To use the version_utils version and fall back to rpm:
 
@@ -106,7 +109,7 @@ def labelCompare(evr_a, evr_b):
     :param tuple evr_a: an EVR tuple
     :param tuple evr_b: an EVR tuple
     """
-    compare_evrs(evr_a, evr_b)
+    return compare_evrs(evr_a, evr_b)
 
 
 def compare_versions(version_a, version_b):
@@ -151,7 +154,7 @@ def compare_versions(version_a, version_b):
     :raises RpmError: if an a type is passed that cannot be converted to
         a list
     """
-    logger.debug('compare_versions({0}, {1})'.format(version_a, version_b))
+    logger.debug('compare_versions(%s, %s)', version_a, version_b)
     if version_a == version_b:
         return a_eq_b
     try:
@@ -160,8 +163,8 @@ def compare_versions(version_a, version_b):
         raise RpmError('Could not compare {0} to '
                        '{1}'.format(version_a, version_b))
     while len(chars_a) != 0 and len(chars_b) != 0:
-        logger.debug('starting loop comparing {0} '
-                     'to {1}'.format(chars_a, chars_b))
+        logger.debug('starting loop comparing %s '
+                     'to %s', chars_a, chars_b)
         _check_leading(chars_a, chars_b)
         if chars_a[0] == '~' and chars_b[0] == '~':
             map(lambda x: x.pop(0), (chars_a, chars_b))
@@ -198,7 +201,7 @@ def package(package_string, arch_included=True):
         information
     :rtype: common.Package
     """
-    logger.debug('package({0}, {1})'.format(package_string, arch_included))
+    logger.debug('package(%s, %s)', package_string, arch_included)
     pkg_info = parse_package(package_string, arch_included)
     pkg = Package(pkg_info['name'], pkg_info['EVR'][0], pkg_info['EVR'][1],
                   pkg_info['EVR'][2], pkg_info['arch'],
@@ -226,20 +229,18 @@ def parse_package(package_string, arch_included=True):
     :rtype: dict
     """
     # Yum sets epoch values to 0 if they are not specified
-    logger.debug('parse_information({0}, '
-                 '{1})'.format(package_string, arch_included))
+    logger.debug('parse_package(%s, %s)', package_string, arch_included)
     default_epoch = '0'
     arch = None
     if arch_included:
         char_list = list(package_string)
         arch = _pop_arch(char_list)
         package_string = ''.join(char_list)
-        logger.debug('updated version_string: {0}'.format(package_string))
+        logger.debug('updated version_string: %s', package_string)
     try:
         name, epoch, version, release = _rpm_re.match(package_string).groups()
     except AttributeError:
-        raise RpmError('Could not parse package string: '
-                       '{0}'.format(package_string))
+        raise RpmError('Could not parse package string: %s' % package_string)
     if epoch == '' or epoch is None:
         epoch = default_epoch
     info = {
@@ -247,7 +248,7 @@ def parse_package(package_string, arch_included=True):
         'EVR': (epoch, version, release),
         'arch': arch
     }
-    logger.debug('parsed information: {0}'.format(info))
+    logger.debug('parsed information: %s', info)
     return info
 
 
@@ -261,7 +262,7 @@ def _pop_arch(char_list):
     :return: the parsed architecture as a string
     :rtype: str
     """
-    logger.debug('_pop_arch{0}'.format(char_list))
+    logger.debug('_pop_arch(%s)', char_list)
     arch_list = []
     char = char_list.pop()
     while char != '.':
@@ -271,7 +272,7 @@ def _pop_arch(char_list):
         except IndexError:  # Raised for a string with no periods
             raise RpmError('Could not parse an architecture. Did you mean to '
                            'set the arch_included flag to False?')
-    logger.debug('arch chars: {0}'.format(arch_list))
+    logger.debug('arch chars: %s', arch_list)
     return ''.join(arch_list)
 
 
@@ -286,12 +287,12 @@ def _check_leading(*char_lists):
     :return: None
     :rtype: None
     """
-    logger.debug('_check_leading{0}'.format(char_lists))
+    logger.debug('_check_leading(%s)', char_lists)
     for char_list in char_lists:
         while (len(char_list) != 0 and not char_list[0].isalnum() and
                 not char_list[0] == '~'):
             char_list.pop(0)
-        logger.debug('updated list: {0}'.format(char_list))
+        logger.debug('updated list: %s', char_list)
 
 
 def _trim_zeros(*char_lists):
@@ -305,11 +306,11 @@ def _trim_zeros(*char_lists):
     :return: None
     :rtype: None
     """
-    logger.debug('_trim_zeros({0})'.format(char_lists))
+    logger.debug('_trim_zeros(%s)', char_lists)
     for char_list in char_lists:
         while len(char_list) != 0 and char_list[0] == '0':
             char_list.pop(0)
-        logger.debug('updated block: {0}'.format(char_list))
+        logger.debug('updated block: %s', char_list)
 
 
 def _pop_digits(char_list):
@@ -323,12 +324,12 @@ def _pop_digits(char_list):
     :return: a list of string digits
     :rtype: list
     """
-    logger.debug('_pop_digits({0})'.format(char_list))
+    logger.debug('_pop_digits(%s)', char_list)
     digits = []
     while len(char_list) != 0 and char_list[0].isdigit():
         digits.append(char_list.pop(0))
-    logger.debug('got digits: {0}'.format(digits))
-    logger.debug('updated char list: {0}'.format(char_list))
+    logger.debug('got digits: %s', digits)
+    logger.debug('updated char list: %s', char_list)
     return digits
 
 
@@ -343,12 +344,12 @@ def _pop_letters(char_list):
     :return: a list of characters
     :rtype: list
     """
-    logger.debug('_pop_letters({0})'.format(char_list))
+    logger.debug('_pop_letters(%s)', char_list)
     letters = []
     while len(char_list) != 0 and char_list[0].isalpha():
         letters.append(char_list.pop(0))
-    logger.debug('got letters: {0}'.format(letters))
-    logger.debug('updated char list: {0}'.format(char_list))
+    logger.debug('got letters: %s', letters)
+    logger.debug('updated char list: %s', char_list)
     return letters
 
 
@@ -378,7 +379,7 @@ def _compare_blocks(block_a, block_b):
         -1 (if ``b`` is newer)
     :rtype: int
     """
-    logger.debug('_compare_blocks({0}, {1})'.format(block_a, block_b))
+    logger.debug('_compare_blocks(%s, %s)', block_a, block_b)
     if block_a[0].isdigit():
         _trim_zeros(block_a, block_b)
         if len(block_a) != len(block_b):
@@ -418,7 +419,7 @@ def _get_block_result(chars_a, chars_b):
         -1 (if ``b`` is newer)
     :rtype: int
     """
-    logger.debug('_get_block_result({0}, {1})'.format(chars_a, chars_b))
+    logger.debug('_get_block_result(%s, %s)', chars_a, chars_b)
     first_is_digit = chars_a[0].isdigit()
     pop_func = _pop_digits if first_is_digit else _pop_letters
     return_if_no_b = a_newer if first_is_digit else b_newer

--- a/version_utils/rpm.py
+++ b/version_utils/rpm.py
@@ -24,7 +24,7 @@ from version_utils.common import Package
 from version_utils.errors import RpmError
 
 
-_rpm_re = compile('(\S+)-(?:(\d*):)?([\w~]+[\w.~]*)-(~?\w+[\w.]*)')
+_rpm_re = compile('(\S+)-(?:(\d*):)?(.*)-(~?\w+[\w.]*)')
 
 logger = getLogger(__name__)
 

--- a/version_utils/version.py
+++ b/version_utils/version.py
@@ -8,5 +8,5 @@ and also set as the __version__ attribute for the package.
 # Standard library imports
 from __future__ import unicode_literals
 
-__version_info__ = (0, 2, 3)
+__version_info__ = (0, 3, 0)
 __version__ = '.'.join([str(ver) for ver in __version_info__])


### PR DESCRIPTION
- Fix for #11 - thanks @furlongm 
- Addition of `labelCompare` function to serve as a drop-in replacement for the same function in the `rpm` package, again thanks to @furlongm 
- Converted tests to py.test format
- Improved logging efficiency
