### PR TITLE
Add missing line in docstring

### DIFF
--- a/version_utils/common.py
+++ b/version_utils/common.py
@@ -28,6 +28,7 @@ class Package(object):
     :ivar str name: package name
     :ivar str epoch: package epoch
     :ivar str version: package version
+    :ivar str release: package release
     :ivar str arch: package architecture
     :ivar tuple evr: a 3-tuple containing (epoch, version, release)
     :ivar tuple info: a 5-tuple containing (name, epoch, version, release,


### PR DESCRIPTION
The Package class has a 'release' attribute, but it was not documented in the docstring.