### PR TITLE
rpm.compare_versions: fix bugs with ~ segments

### DIFF
--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -363,7 +363,9 @@ def test_get_block_res(str_a, str_b, exp):
     ('12345.6', '12345.6', 0),
     ('0.2.3', '1.2.4', -1),
     ('~1.2.3', '1.2.3', -1),
-    ('1.2.3.a', '1.2.3.~alpha', 1)
+    ('1.2.3.a', '1.2.3.~alpha', 1),
+    ('a~1.2.3', 'a', -1),
+    ('a', 'a~1.2.3', 1)
 ])
 def test_compare_versions(ver_a, ver_b, exp):
     res = rpm.compare_versions(ver_a, ver_b)

--- a/tests/test_rpm.py
+++ b/tests/test_rpm.py
@@ -365,7 +365,11 @@ def test_get_block_res(str_a, str_b, exp):
     ('~1.2.3', '1.2.3', -1),
     ('1.2.3.a', '1.2.3.~alpha', 1),
     ('a~1.2.3', 'a', -1),
-    ('a', 'a~1.2.3', 1)
+    ('a', 'a~1.2.3', 1),
+    ('~1.2.3', '~1.2.4', -1),
+    ('~1.2.4', '~1.2.3', 1),
+    ('~~1.2.3', '~~1.2.4', -1),
+    ('~~1.2.4', '~~1.2.3', 1)
 ])
 def test_compare_versions(ver_a, ver_b, exp):
     res = rpm.compare_versions(ver_a, ver_b)

--- a/version_utils/rpm.py
+++ b/version_utils/rpm.py
@@ -142,7 +142,8 @@ def compare_versions(version_a, version_b):
     remaining character lists are compared. If they have the same length
     (usually 0, since all characters have been popped), they are
     considered to be equal. Otherwise, whichever is longer is considered
-    to be newer. Generally, unequal length will be due to one character
+    to be newer, unless it starts with a ~, in which case it is considered
+    be older. Generally, unequal length will be due to one character
     list having been completely consumed while some characters remain on
     the other, for example when comparing 1.05b to 1.05.
 
@@ -182,7 +183,10 @@ def compare_versions(version_a, version_b):
         return a_eq_b
     else:
         logger.debug('versions not equal')
-        return a_newer if len(chars_a) > len(chars_b) else b_newer
+        if len(chars_a) > len(chars_b):
+            return b_newer if chars_a[0] == '~' else a_newer
+        else:
+            return a_newer if chars_b[0] == '~' else b_newer
 
 
 def package(package_string, arch_included=True):

--- a/version_utils/rpm.py
+++ b/version_utils/rpm.py
@@ -168,7 +168,9 @@ def compare_versions(version_a, version_b):
                      'to %s', chars_a, chars_b)
         _check_leading(chars_a, chars_b)
         if chars_a[0] == '~' and chars_b[0] == '~':
-            map(lambda x: x.pop(0), (chars_a, chars_b))
+            chars_a.pop(0)
+            chars_b.pop(0)
+            continue
         elif chars_a[0] == '~':
             return b_newer
         elif chars_b[0] == '~':


### PR DESCRIPTION
This PR fixes several bugs that I noticed when I compared the result of sorting all Fedora 35 packages between:

1. version_utils.rpm.compare_versions()
2. rpm.labelCompare()  from the librpm Python bindings

With these fixes, the sorting of that test dataset is the same. (The ~~ test case doesn't exist in that dataset - it's artificial to show the badness from calling  _get_block_result() without proceeding to the next pass of the loop. I did check that RPM handles it the same way as the test case.)

I haven't reviewed the librpm sources and make no guarantees that the order is the same for *all* possible inputs. :-)
 